### PR TITLE
chore: make bucket variable

### DIFF
--- a/extract/action.yml
+++ b/extract/action.yml
@@ -10,6 +10,9 @@ inputs:
   mounts:
     description: Docker build cache mounts list
     required: true
+  bucket:
+    description: Bucket name
+    required: true
 
 runs:
   using: composite
@@ -41,5 +44,5 @@ runs:
         FROM peakcom/s5cmd:v2.1.0
         COPY buildstamp buildstamp
         RUN ${{ steps.mounts.outputs.result }} \
-            /s5cmd --stat --log error sync --no-follow-symlinks '/cache-mounts/*' s3://platform-runner-cache/cache-mounts/
+            /s5cmd --stat --log error sync --no-follow-symlinks '/cache-mounts/*' s3://${bucket}/cache-mounts/
         EOF

--- a/extract/action.yml
+++ b/extract/action.yml
@@ -44,5 +44,5 @@ runs:
         FROM peakcom/s5cmd:v2.1.0
         COPY buildstamp buildstamp
         RUN ${{ steps.mounts.outputs.result }} \
-            /s5cmd --stat --log error sync --no-follow-symlinks '/cache-mounts/*' s3://${bucket}/cache-mounts/
+            /s5cmd --stat --log error sync --no-follow-symlinks '/cache-mounts/*' s3://${inputs.bucket}/cache-mounts/
         EOF

--- a/extract/action.yml
+++ b/extract/action.yml
@@ -44,5 +44,5 @@ runs:
         FROM peakcom/s5cmd:v2.1.0
         COPY buildstamp buildstamp
         RUN ${{ steps.mounts.outputs.result }} \
-            /s5cmd --stat --log error sync --no-follow-symlinks '/cache-mounts/*' s3://${inputs.bucket}/cache-mounts/
+            /s5cmd --stat --log error sync --no-follow-symlinks '/cache-mounts/*' s3://${{inputs.bucket}}/cache-mounts/
         EOF

--- a/inject/action.yml
+++ b/inject/action.yml
@@ -41,7 +41,7 @@ runs:
           )).join(' ');
           
           const s5commands = mountIds.map((mount) => (
-            `sync --no-follow-symlinks s3://${bucket}/cache-mounts/${mount}/* /cache-mounts/${mount}`
+            `sync --no-follow-symlinks s3://${inputs.bucket}/cache-mounts/${mount}/* /cache-mounts/${mount}`
           )).join('\n');
 
           core.setOutput('cacheMountArgs', cacheMountArgs);

--- a/inject/action.yml
+++ b/inject/action.yml
@@ -41,7 +41,7 @@ runs:
           )).join(' ');
           
           const s5commands = mountIds.map((mount) => (
-            `sync --no-follow-symlinks s3://${inputs.bucket}/cache-mounts/${mount}/* /cache-mounts/${mount}`
+            `sync --no-follow-symlinks s3://${{inputs.bucket}}/cache-mounts/${mount}/* /cache-mounts/${mount}`
           )).join('\n');
 
           core.setOutput('cacheMountArgs', cacheMountArgs);

--- a/inject/action.yml
+++ b/inject/action.yml
@@ -10,6 +10,9 @@ inputs:
   mounts:
     description: Docker build cache mounts list
     required: true
+  bucket:
+    description: Bucket name
+    required: true
 
 runs:
   using: composite
@@ -38,7 +41,7 @@ runs:
           )).join(' ');
           
           const s5commands = mountIds.map((mount) => (
-            `sync --no-follow-symlinks s3://platform-runner-cache/cache-mounts/${mount}/* /cache-mounts/${mount}`
+            `sync --no-follow-symlinks s3://${bucket}/cache-mounts/${mount}/* /cache-mounts/${mount}`
           )).join('\n');
 
           core.setOutput('cacheMountArgs', cacheMountArgs);


### PR DESCRIPTION
Modifying https://github.com/dcginfra/tf-aws-gh-runner/ to a multi-runner config means different runners should access different buckets. This PR adds the `bucket` input as a variable to support this use case.