### PR TITLE
chore: switch to aws-cli

### DIFF
--- a/extract/action.yml
+++ b/extract/action.yml
@@ -41,8 +41,8 @@ runs:
       shell: bash
       run: |
         docker build ${{ inputs.scratch-dir }} --file - <<EOF
-        FROM peakcom/s5cmd:v2.1.0
+        FROM amazon/aws-cli:2.13.17
         COPY buildstamp buildstamp
         RUN ${{ steps.mounts.outputs.result }} \
-            /s5cmd --stat --log error sync --no-follow-symlinks '/cache-mounts/*' s3://${{inputs.bucket}}/cache-mounts/
+            aws s3 sync --no-follow-symlinks --quiet /cache-mounts s3://${{inputs.bucket}}/cache-mounts
         EOF

--- a/extract/action.yml
+++ b/extract/action.yml
@@ -37,7 +37,7 @@ runs:
             ))
             .join(' ');
 
-    - name: Extract Data into buildx context
+    - name: Extract cache data from buildx context
       shell: bash
       run: |
         docker build ${{ inputs.scratch-dir }} --file - <<EOF

--- a/inject/action.yml
+++ b/inject/action.yml
@@ -51,7 +51,7 @@ runs:
       shell: bash
       run: |
         docker build ${{ inputs.cache-source }} --file - <<EOF
-        FROM amazon/aws-cli:2.13.16
+        FROM amazon/aws-cli:2.13.17
         COPY buildstamp buildstamp
         RUN ${{ steps.mounts.outputs.cacheMountArgs }} <<EOT
             echo -e '${{ steps.mounts.outputs.s3commands }}' | sh && \

--- a/inject/action.yml
+++ b/inject/action.yml
@@ -45,13 +45,14 @@ runs:
           )).join('\n');
 
           core.setOutput('cacheMountArgs', cacheMountArgs);
-          core.setOutput('s5commands', s5commands);
+          core.setOutput('s3commands', s3commands);
 
     - name: Inject Data into buildx context
       shell: bash
       run: |
         docker build ${{ inputs.cache-source }} --file - <<EOF
         FROM amazon/aws-cli:2.13.16
+        RUN yum install -y tree
         COPY buildstamp buildstamp
         RUN ${{ steps.mounts.outputs.cacheMountArgs }} <<EOT
             echo '${{ steps.mounts.outputs.s3commands }}' | sh && \

--- a/inject/action.yml
+++ b/inject/action.yml
@@ -41,7 +41,7 @@ runs:
           )).join(' ');
           
           const s3commands = mountIds.map((mount) => (
-            `aws s3 sync --no-follow-symlinks s3://${{inputs.bucket}}/cache-mounts/${mount} /cache-mounts/${mount}`
+            `aws s3 sync --no-follow-symlinks --quiet s3://${{inputs.bucket}}/cache-mounts/${mount} /cache-mounts/${mount}`
           )).join('\n');
 
           core.setOutput('cacheMountArgs', cacheMountArgs);

--- a/inject/action.yml
+++ b/inject/action.yml
@@ -52,12 +52,10 @@ runs:
       run: |
         docker build ${{ inputs.cache-source }} --file - <<EOF
         FROM amazon/aws-cli:2.13.16
-        RUN yum install -y tree
         COPY buildstamp buildstamp
         RUN ${{ steps.mounts.outputs.cacheMountArgs }} <<EOT
             echo -e '${{ steps.mounts.outputs.s3commands }}' | sh && \
-            chmod 777 -R /cache-mounts || true && \
-            tree -D -L 4 --timefmt '%Y-%m-%d %H:%M:%S' /cache-mounts || true
+            chmod 777 -R /cache-mounts || true
         EOT
         EOF
 

--- a/inject/action.yml
+++ b/inject/action.yml
@@ -40,8 +40,8 @@ runs:
             `--mount=type=cache,sharing=shared,id=${mount},target=/cache-mounts/${mount}`
           )).join(' ');
           
-          const s5commands = mountIds.map((mount) => (
-            `sync --no-follow-symlinks s3://${{inputs.bucket}}/cache-mounts/${mount}/* /cache-mounts/${mount}`
+          const s3commands = mountIds.map((mount) => (
+            `aws s3 sync --no-follow-symlinks s3://${{inputs.bucket}}/cache-mounts/${mount}/* /cache-mounts/${mount}`
           )).join('\n');
 
           core.setOutput('cacheMountArgs', cacheMountArgs);
@@ -51,12 +51,12 @@ runs:
       shell: bash
       run: |
         docker build ${{ inputs.cache-source }} --file - <<EOF
-        FROM peakcom/s5cmd:v2.1.0
+        FROM amazon/aws-cli:2.13.16
         COPY buildstamp buildstamp
         RUN ${{ steps.mounts.outputs.cacheMountArgs }} <<EOT
-            echo '${{ steps.mounts.outputs.s5commands }}' | /s5cmd --stat --log error run && \
+            echo '${{ steps.mounts.outputs.s3commands }}' | sh && \
             chmod 777 -R /cache-mounts || true && \
-            find /cache-mounts -exec touch -d `date +%Y.%m.%d-%H:%M:%S -d@"$((\`date +%s\`-2))"` {} +
+            tree -D -L 4 --timefmt '%Y-%m-%d %H:%M:%S' /cache-mounts || true
         EOT
         EOF
 

--- a/inject/action.yml
+++ b/inject/action.yml
@@ -47,7 +47,7 @@ runs:
           core.setOutput('cacheMountArgs', cacheMountArgs);
           core.setOutput('s3commands', s3commands);
 
-    - name: Inject Data into buildx context
+    - name: Inject cache data into buildx context
       shell: bash
       run: |
         docker build ${{ inputs.cache-source }} --file - <<EOF

--- a/inject/action.yml
+++ b/inject/action.yml
@@ -41,7 +41,7 @@ runs:
           )).join(' ');
           
           const s3commands = mountIds.map((mount) => (
-            `aws s3 sync --no-follow-symlinks s3://${{inputs.bucket}}/cache-mounts/${mount}/* /cache-mounts/${mount}`
+            `aws s3 sync --no-follow-symlinks s3://${{inputs.bucket}}/cache-mounts/${mount} /cache-mounts/${mount}`
           )).join('\n');
 
           core.setOutput('cacheMountArgs', cacheMountArgs);

--- a/inject/action.yml
+++ b/inject/action.yml
@@ -55,7 +55,7 @@ runs:
         RUN yum install -y tree
         COPY buildstamp buildstamp
         RUN ${{ steps.mounts.outputs.cacheMountArgs }} <<EOT
-            echo '${{ steps.mounts.outputs.s3commands }}' | sh && \
+            echo -e '${{ steps.mounts.outputs.s3commands }}' | sh && \
             chmod 777 -R /cache-mounts || true && \
             tree -D -L 4 --timefmt '%Y-%m-%d %H:%M:%S' /cache-mounts || true
         EOT


### PR DESCRIPTION
s5cmd does not currently support maintaining mtime when syncing with s3, see tracking issue: https://github.com/peak/s5cmd/pull/534

Until this is available, we need to use the slower aws-cli tool instead.